### PR TITLE
update Makefile to use uv run for kedro submit; modify kedro-argo dependency to be editable

### DIFF
--- a/argo-test/Makefile
+++ b/argo-test/Makefile
@@ -2,4 +2,4 @@ IMAGE := us-central1-docker.pkg.dev/mtrx-hub-dev-3of/matrix-images/fuse:laurens
 NAMESPACE := argo-workflows
 
 submit:
-	kedro submit --image ${IMAGE} --namespace ${NAMESPACE} --environment cloud -p data_processing
+	uv run kedro submit --image ${IMAGE} --namespace ${NAMESPACE} --environment cloud -p data_processing

--- a/argo-test/pyproject.toml
+++ b/argo-test/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "scikit-learn~=1.5.1",
     "seaborn~=0.12.1",
     "kubernetes",
-    "kedro-argo @ file:///Users/laurens/Documents/projects/kedro-argo/kedro-argo",
+    "kedro-argo",
     "gcsfs"
 ]
 
@@ -78,3 +78,6 @@ ignore = [
 
 [tool.kedro_telemetry]
 project_id = "ac60f8a981ee4ae8a2a0d6d8d7d28ee1"
+
+[tool.uv.sources]
+kedro-argo = { path = "../kedro-argo", editable = true }

--- a/argo-test/uv.lock
+++ b/argo-test/uv.lock
@@ -153,7 +153,7 @@ requires-dist = [
     { name = "ipython", specifier = ">=8.10" },
     { name = "jupyterlab", specifier = ">=3.0" },
     { name = "kedro", extras = ["jupyter"], specifier = "~=1.1.1" },
-    { name = "kedro-argo", directory = "../kedro-argo" },
+    { name = "kedro-argo", editable = "../kedro-argo" },
     { name = "kedro-datasets", extras = ["matplotlib-matplotlibdataset", "pandas-csvdataset", "pandas-exceldataset", "pandas-parquetdataset", "plotly-jsondataset", "plotly-plotlydataset"], specifier = ">=3.0" },
     { name = "kedro-viz", specifier = ">=6.7.0" },
     { name = "kubernetes" },
@@ -1334,7 +1334,7 @@ jupyter = [
 [[package]]
 name = "kedro-argo"
 version = "0.1.0"
-source = { directory = "../kedro-argo" }
+source = { editable = "../kedro-argo" }
 dependencies = [
     { name = "jinja2" },
     { name = "kedro" },


### PR DESCRIPTION
This pull request introduces improvements to the workflow and dependency management for the `argo-test` project. The main changes focus on updating how Kedro jobs are submitted and refining how the `kedro-argo` dependency is managed for local development.

**Workflow and Dependency Management Updates:**

* Kedro job submission now uses `uv run` for execution, which can improve dependency resolution and environment management in the `Makefile`.

* The `kedro-argo` dependency is now referenced by name in the `pyproject.toml` instead of using a local file path, simplifying the dependency specification.

* Added a `[tool.uv.sources]` section to `pyproject.toml` to specify a local, editable source for `kedro-argo`, making local development and testing of this package easier.