### PR TITLE
updated the github action to publish the correct readme file

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install build twine
     
+    - name: Copy root README into package directory
+      run: cp README.md argo-kedro/README.md
+
     - name: Build package
       working-directory: argo-kedro
       run: python -m build

--- a/argo-kedro/pyproject.toml
+++ b/argo-kedro/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "argo-kedro"
-version = "0.1.13"
+version = "0.1.14"
 description = "Kedro plugin for running pipelines on Argo Workflows"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This pull request makes minor changes to the packaging and publishing process for the `argo-kedro` Python package. The version is incremented and the workflow now ensures the `README.md` is included in the package directory before building.

- Packaging and publishing improvements:
  * The GitHub Actions workflow (`.github/workflows/publish.yml`) now copies the root `README.md` into the `argo-kedro` package directory before building, ensuring the package includes the correct README.
  * The package version in `argo-kedro/pyproject.toml` is bumped from `0.1.13` to `0.1.14`.